### PR TITLE
Typo fix

### DIFF
--- a/src/JildertMiedema/LaravelPlupload/Receiver.php
+++ b/src/JildertMiedema/LaravelPlupload/Receiver.php
@@ -16,11 +16,10 @@ class Receiver {
 
     public function getPath()
     {
-        $path = storage_path() . '/pluload';
+        $path = storage_path() . '/plupload';
 
-        if (!file_exists($path))
-        {
-            mkdir($path);
+        if (!is_dir($path)) {
+            mkdir($path, 0777, true);
         }
 
         return $path;


### PR DESCRIPTION
- fixed typo in directory name (pluload to plupload),
- suggestions:
- changing file_exists to is_dir while actually checking for a directory,
- recursive=true in mkdir() might actually be safer
