### PR TITLE
Not using namespaces when triggering exception causes fatal error in Laravel 5

### DIFF
--- a/src/JildertMiedema/LaravelPlupload/PluploadException.php
+++ b/src/JildertMiedema/LaravelPlupload/PluploadException.php
@@ -1,3 +1,3 @@
 <?php namespace JildertMiedema\LaravelPlupload;
 
-class PluploadException extends Exception {}
+class PluploadException extends \Exception {}

--- a/src/JildertMiedema/LaravelPlupload/Receiver.php
+++ b/src/JildertMiedema/LaravelPlupload/Receiver.php
@@ -92,7 +92,7 @@ class Receiver {
 
     public function receive($name, Closure $handler)
     {
-		$response = array();
+	$response = array();
         $response['jsonrpc'] = "2.0";
 
         if ($this->hasChunks()) {

--- a/src/JildertMiedema/LaravelPlupload/Receiver.php
+++ b/src/JildertMiedema/LaravelPlupload/Receiver.php
@@ -92,7 +92,7 @@ class Receiver {
 
     public function receive($name, Closure $handler)
     {
-        $response = [];
+		$response = array();
         $response['jsonrpc'] = "2.0";
 
         if ($this->hasChunks()) {

--- a/src/JildertMiedema/LaravelPlupload/Receiver.php
+++ b/src/JildertMiedema/LaravelPlupload/Receiver.php
@@ -2,6 +2,7 @@
 
 use Closure;
 use Illuminate\Http\Request;
+use JildertMiedema\LaravelPlupload\PluploadException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class Receiver {
@@ -91,7 +92,7 @@ class Receiver {
 
     public function receive($name, Closure $handler)
     {
-        $response = array();
+        $response = [];
         $response['jsonrpc'] = "2.0";
 
         if ($this->hasChunks()) {


### PR DESCRIPTION
In my case I get this bug (in Laravel 5 only) when I'm tring to upload bigger files thene the max allowed upload size in PHP configuration.